### PR TITLE
Remove deprecated children of <website>

### DIFF
--- a/source/frontmatter.ptx
+++ b/source/frontmatter.ptx
@@ -18,8 +18,7 @@
   <colophon>
 
     <website>
-      <name>Your Website</name>
-      <address>"https://pretextbook.org"</address>
+      <url>"https://pretextbook.org"</url>
     </website>
 
     <copyright>


### PR DESCRIPTION
Creating a new pretext project off of this template results in a warning out of the box:
```    * PTX:DEPRECATE: (2023-08-08) a "website" element with "address" and "name" children has changed.  Continue to use the "website" element as before, but replace the "address" and "name" children with a single "url" element, which is more flexible and reliable.  We will try to honor your intent, but you may prefer your own adjustments. (1 time)
    *              located within: "frontmatter" (xml:id)
    * -------------- ```

This removes the deprecated `<address>` and `<name>` from the template and replaces them with `<url>` as suggested.